### PR TITLE
Add a functional test harness for JUnit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   val indraVersion = "2.0.4"
+  `java-test-fixtures`
   id("net.kyori.indra") version indraVersion
   id("net.kyori.indra.license-header") version indraVersion
   id("net.kyori.indra.publishing.sonatype") version indraVersion
@@ -16,6 +17,9 @@ repositories {
 dependencies {
   compileOnlyApi("org.checkerframework:checker-qual:3.13.0")
   implementation(gradleApi())
+  testFixturesApi(gradleTestKit())
+  testFixturesApi("org.junit.jupiter:junit-jupiter-api:5.7.2")
+  testFixturesImplementation("org.junit.platform:junit-platform-commons:1.7.2")
 }
 
 indra {

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,53 @@
 # mammoth
 
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/KyoriPowered/mammoth/build/master) [![MIT License](https://img.shields.io/badge/license-MIT-blue)](license.txt)
+
+## Plugin Utilities
+
+The main component of `mammoth` is utility functions for developing Gradle plugins in java, plus `ProjectPlugin`, an interface for plugins for `Project` instances.
+
+## Functional Testing
+
+Mammoth provides test fixtures to enable functional testing of Gradle plugins. This architecture is designed for Java tests using JUnit 5, with the buildscripts for tested builds stored as classpath resources. This stands in contrast to Groovy functional tests, where the buildscript is written as a string directly in the test class.
+
+<details>
+<summary>Example</summary>
+
+Assuming there are files at `src/test/resources/com/example/myplugin/simpleBuild/in/build.gradle.kts` and `src/test/resources/com/example/myplugin/simpleBuild/in/settings.gradle.kts`, the following sets up a simple test that will run on both Gradle 6.9 and 7.1:
+
+**com/example/myplugin/MyPluginTest.java**:
+
+```java
+/**
+ * A <em>meta-annotation containing our test configuration.</em>
+ */
+@GradleFunctionalTest
+@GradleParameters({"--warning-mode", "all", "--stacktrace"}) // parameters for all variants
+@TestVariant(gradleVersion = "6.9")
+@TestVariant(gradleVersion = "7.1")
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+public @interface MyPluginTest {
+}
+```
+
+**com/example/myplugin/MyPluginFunctionalTest.java**
+```java
+
+class MyPluginFunctionalTest {
+
+  @SpongeGradleFunctionalTest
+  void simpleBuild(final TestContext ctx) {
+    ctx.copyInput("build.gradle.kts");
+    ctx.copyInput("settings.gradle.kts");
+
+    final BuildResult result = ctx.build("build"); // or anoher
+
+    assertEquals(TaskOutcome.SUCCESS, result.task(":build").getOutcome());
+    
+    // Use any other methods on TestContext to help validate output.
+  }
+}
+```
+</details>

--- a/src/testFixtures/java/net/kyori/mammoth/test/GradleFunctionalTest.java
+++ b/src/testFixtures/java/net/kyori/mammoth/test/GradleFunctionalTest.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of mammoth, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.mammoth.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Indicate that the annotated test method will be a Gradle functional test.
+ *
+ * <p>This annotation can be used as a <em>meta-annotation</em> to create a project-specific annotation specifying all customizable parameters.</p>
+ *
+ * <p>The annotated method can receive a {@link TestContext} instance in its parameters to support a standard directory layout.</p>
+ *
+ * <p>This directory layout follows a pattern of {@code <test class package>/<test name>/in/} for test input files,
+ * and {@code <test class package>/<test name>/out/} for expected output files. Test output will be written to a temporary
+ * directory, and deleted after test execution.</p>
+ *
+ * @see GradleParameters
+ * @see TestVariant
+ * @since 1.1.0
+ */
+@Documented
+@TestTemplate
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@ExtendWith(GradleFunctionalTestExtension.class)
+public @interface GradleFunctionalTest {
+}

--- a/src/testFixtures/java/net/kyori/mammoth/test/GradleFunctionalTestExtension.java
+++ b/src/testFixtures/java/net/kyori/mammoth/test/GradleFunctionalTestExtension.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of mammoth, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.mammoth.test;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.gradle.util.GradleVersion;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+/**
+ * An extension that can be applied to test methods to provide test template invocation context.
+ */
+class GradleFunctionalTestExtension implements TestTemplateInvocationContextProvider {
+  @Override
+  public boolean supportsTestTemplate(final ExtensionContext context) {
+    final Optional<Method> method = context.getTestMethod();
+    if (!method.isPresent()) {
+      return false;
+    }
+
+    return AnnotationSupport.isAnnotated(method, GradleFunctionalTest.class);
+  }
+
+  @Override
+  public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(final ExtensionContext context) {
+    final Optional<GradleParameters> parameters = AnnotationSupport.findAnnotation(context.getElement(), GradleParameters.class);
+    final List<TestVariant> variants = AnnotationSupport.findRepeatableAnnotations(context.getElement(), TestVariant.class);
+    final String[] commonArgs = parameters.map(GradleParameters::value).orElse(new String[0]);
+
+    // Execute the actual tests
+    if (variants.isEmpty()) { // populate with one variant for the current Gradle version
+      return Stream.of(this.produce(context, commonArgs, ""));
+    } else {
+      return variants.stream()
+        .map(variant -> this.produce(context, commonArgs, variant.gradleVersion(), variant.extraArguments()));
+    }
+  }
+
+  private TestTemplateInvocationContext produce(final ExtensionContext context, final String[] commonArgs, final String gradleVersion, final String... extraArguments) {
+    final List<String> extraArgs = processArgs(commonArgs, extraArguments);
+    final Path tempDirectory;
+    try {
+      tempDirectory = Files.createTempDirectory(context.getRequiredTestClass().getSimpleName());
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    final TestContext testContext = new TestContext(
+      context.getRequiredTestClass(),
+      context.getDisplayName(),
+      tempDirectory,
+      gradleVersion.isEmpty() ? GradleVersion.current().getVersion() : gradleVersion,
+      extraArgs
+    );
+
+    return new TestTemplateInvocationContext() {
+      @Override
+      public String getDisplayName(final int invocationIndex) {
+        return "gradle " + testContext.gradleVersion() + ", args=" + extraArgs;
+      }
+
+      @Override
+      public List<Extension> getAdditionalExtensions() {
+        return Collections.singletonList(new TemplateInvocationExtensions(testContext));
+      }
+    };
+  }
+
+  private static List<String> processArgs(final String[] common, final String[] extra) {
+    final List<String> ret = new ArrayList<>(common.length + extra.length);
+    Collections.addAll(ret, common);
+    Collections.addAll(ret, extra);
+    return ret;
+  }
+}

--- a/src/testFixtures/java/net/kyori/mammoth/test/GradleParameters.java
+++ b/src/testFixtures/java/net/kyori/mammoth/test/GradleParameters.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of mammoth, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.mammoth.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Parameters to provide to Gradle on test invocations.
+ *
+ * @since 1.1.0
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+public @interface GradleParameters {
+  /**
+   * The Gradle parameters.
+   *
+   * @return an array of parameters
+   * @since 1.1.0
+   */
+  String[] value();
+}

--- a/src/testFixtures/java/net/kyori/mammoth/test/TemplateInvocationExtensions.java
+++ b/src/testFixtures/java/net/kyori/mammoth/test/TemplateInvocationExtensions.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of mammoth, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.mammoth.test;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+// Template-specific context information
+class TemplateInvocationExtensions implements AfterEachCallback, ParameterResolver {
+  private final TestContext context;
+
+  TemplateInvocationExtensions(final TestContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public void afterEach(final ExtensionContext context) throws Exception {
+    try {
+      Files.walkFileTree(this.context.outputDirectory(), DeletingFileVisitor.INSTANCE);
+    } catch (final IOException ex) {
+      // Don't fail the tests for failing to delete temporary directories
+      // Windows can be a bit needy with file locking...
+      // Just warn instead
+      // And of course, we can't depend on a logging system (and we're not J9+)
+      System.err.println("Failed to delete temporary directory for test " + this.getClass().getSimpleName());
+      ex.printStackTrace();
+    }
+  }
+
+  @Override
+  public boolean supportsParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext) throws ParameterResolutionException {
+    return TestContext.class.isAssignableFrom(parameterContext.getParameter().getType());
+  }
+
+  @Override
+  public Object resolveParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext) throws ParameterResolutionException {
+    return this.context;
+  }
+
+  static final class DeletingFileVisitor extends SimpleFileVisitor<Path> {
+    static final DeletingFileVisitor INSTANCE = new DeletingFileVisitor();
+
+    private DeletingFileVisitor() {
+    }
+
+    @Override
+    public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+      Files.deleteIfExists(file);
+      return super.visitFile(file, attrs);
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
+      Files.deleteIfExists(dir);
+      return super.postVisitDirectory(dir, exc);
+    }
+  }
+}

--- a/src/testFixtures/java/net/kyori/mammoth/test/TestContext.java
+++ b/src/testFixtures/java/net/kyori/mammoth/test/TestContext.java
@@ -1,0 +1,200 @@
+/*
+ * This file is part of mammoth, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.mammoth.test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * Context information for individual tests.
+ *
+ * <p>Within this class, all input paths are for classpath resources relative to the current test class.</p>
+ *
+ * @since 1.1.0
+ */
+public final class TestContext {
+  private static final Pattern LINE_ENDING = Pattern.compile("\r\n");
+
+  private final Class<?> resourceBase;
+  private final String testName;
+  private final Path outputDirectory;
+  private final String gradleVersion;
+  private final List<String> commonArguments;
+
+  TestContext(
+    final Class<?> resourceBase,
+    final String testName,
+    final Path outputDirectory,
+    final String gradleVersion,
+    final List<String> commonArguments
+  ) {
+    this.resourceBase = resourceBase;
+    this.testName = testName;
+    this.outputDirectory = outputDirectory;
+    this.gradleVersion = gradleVersion;
+    this.commonArguments = commonArguments;
+  }
+
+  /**
+   * The output directory for the Gradle build.
+   *
+   * @return the output directory
+   * @since 1.1.0
+   */
+  public Path outputDirectory() {
+    return this.outputDirectory;
+  }
+
+  String gradleVersion() {
+    return this.gradleVersion;
+  }
+
+  /**
+   * Copy a resource from the {@code <testName>/in/} directory to the run directory with no changes.
+   *
+   * @param name the input relative to the test's directory
+   * @since 1.1.0
+   */
+  public void copyInput(final String name) throws IOException {
+    this.copyInput(name, name);
+  }
+
+  /**
+   * copy a resource from the {@code <testName>/in/} directory to the run directory with the provided new name.
+   *
+   * @param fromName the name relative to the input
+   * @param toName the name to use in the test's output directory
+   * @since 1.1.0
+   */
+  public void copyInput(final String fromName, final String toName) throws IOException {
+    try (final InputStream is = this.resourceBase.getResourceAsStream(this.testName + "/in/" + fromName)) {
+      Assertions.assertNotNull(is, () -> "No resource found with name " + fromName);
+      final Path destination = this.outputDirectory.resolve(toName);
+      Files.createDirectories(destination.getParent());
+      try (final OutputStream os = Files.newOutputStream(destination)) {
+        final byte[] buffer = new byte[8192];
+        int read;
+        while ((read = is.read(buffer)) != -1) {
+          os.write(buffer, 0, read);
+        }
+      }
+    }
+  }
+
+  /**
+   * Expect that a file is present in the output directory with the provided path.
+   *
+   * @param fileName the file name
+   * @return the contents of the file as a string
+   * @throws IOException if thrown while attempting to read the output file
+   * @since 1.1.0
+   */
+  public String readOutput(final String fileName) throws IOException {
+    final StringBuilder builder = new StringBuilder();
+    try (final BufferedReader reader = Files.newBufferedReader(this.outputDirectory.resolve(fileName), StandardCharsets.UTF_8)) {
+      final char[] buffer = new char[8192];
+      int read;
+      while ((read = reader.read(buffer)) != -1) {
+        builder.append(buffer, 0, read);
+      }
+    }
+    return TestContext.normalizeLineEndings(builder.toString());
+  }
+
+  /**
+   * Expect that the contents of the output file {@code fileName} is equal to
+   * the contents of the resource at  {@code <testName>/out/<resourceName>}.
+   *
+   * @param resourceName the name of the expected resource
+   * @param fileName the name of the actual output file
+   * @throws IOException if failed to read one of the files
+   * @since 1.1.0
+   */
+  public void assertOutputEquals(final String resourceName, final String fileName) throws IOException {
+    final String actualOutput = this.readOutput(fileName);
+
+    final StringBuilder builder = new StringBuilder();
+    final InputStream is = this.resourceBase.getResourceAsStream(this.testName + "/out/" + resourceName);
+    Assertions.assertNotNull(is, () -> "No resource found with name " + resourceName);
+
+    try (final BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+      final char[] buffer = new char[8192];
+      int read;
+      while ((read = reader.read(buffer)) != -1) {
+        builder.append(buffer, 0, read);
+      }
+    }
+
+    final String expected = TestContext.normalizeLineEndings(builder.toString());
+
+    Assertions.assertEquals(expected, actualOutput);
+  }
+
+  /**
+   * Create a new Gradle runner.
+   *
+   * @param extraArgs extra arguments to provide
+   * @return the new runner
+   * @since 1.1.0
+   */
+  public GradleRunner runner(final String... extraArgs) {
+    final List<String> args = new ArrayList<>(this.commonArguments.size() + extraArgs.length);
+    args.addAll(this.commonArguments);
+    Collections.addAll(args, extraArgs);
+
+    return GradleRunner.create()
+      .withGradleVersion(this.gradleVersion)
+      .withPluginClasspath()
+      .withProjectDir(this.outputDirectory.toFile())
+      .withArguments(args);
+  }
+
+  /**
+   * Create and execute a new Gradle runner.
+   *
+   * @param extraArgs the extra arguments to provide
+   * @return the result of an executed build
+   * @since 1.1.0
+   */
+  public BuildResult build(final String... extraArgs) {
+    return this.runner(extraArgs).build();
+  }
+
+  static String normalizeLineEndings(final String input) {
+    return TestContext.LINE_ENDING.matcher(input).replaceAll("\n");
+  }
+}

--- a/src/testFixtures/java/net/kyori/mammoth/test/TestVariant.java
+++ b/src/testFixtures/java/net/kyori/mammoth/test/TestVariant.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of mammoth, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.mammoth.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A variant of a test to execute.
+ *
+ * <p>At least one of {@link #gradleVersion()} or {@link #extraArguments()} must be provided.</p>
+ *
+ * <p>This annotation can be used as a composable meta-annotation for </p>
+ *
+ * @since 1.1.0
+ */
+@Documented
+@Repeatable(TestVariants.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+public @interface TestVariant {
+  /**
+   * A gradle version ID.
+   *
+   * <p>This is only validated at test execution time.</p>
+   *
+   * @return the gradle version to test against
+   * @since 1.1.0
+   */
+  String gradleVersion() default "";
+  /**
+   * Extra arguments to provide.
+   *
+   * @return the extra arguments
+   * @since 1.1.0
+   */
+  String[] extraArguments() default {};
+}

--- a/src/testFixtures/java/net/kyori/mammoth/test/TestVariants.java
+++ b/src/testFixtures/java/net/kyori/mammoth/test/TestVariants.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of mammoth, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.mammoth.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A {@link Repeatable} container for {@link TestVariant} annotations.
+ *
+ * @since 1.1.0
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+public @interface TestVariants {
+  /**
+   * The variants to use.
+   *
+   * @return the variants
+   * @since 1.1.0
+   */
+  TestVariant[] value();
+}

--- a/src/testFixtures/java/net/kyori/mammoth/test/package-info.java
+++ b/src/testFixtures/java/net/kyori/mammoth/test/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of mammoth, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * JUnit extensions for developing Gradle functional tests.
+ *
+ * <p>Mammoth provides a {@link org.junit.jupiter.api.TestTemplate} for Gradle functional tests via {@link net.kyori.mammoth.test.GradleFunctionalTest}
+ * annotating methods that have a parameter of either type {@link net.kyori.mammoth.test.TestContext}
+ * or {@link org.gradle.testkit.runner.GradleRunner}.</p>
+ */
+package net.kyori.mammoth.test;


### PR DESCRIPTION
This is a simple functional test harness based on SpongeGradle.

Right now, this is distributed as a test fixtures variant of `mammoth`, meaning it should be automatically exposed to test configurations in plugins that depend on `mammoth`, but it's a bit less clear. We might want to move it into a separate submodule?

Example of converting SpongeGradle incoming